### PR TITLE
Feature/laravel 7-support

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.ref }}
+          fetch-depth: 0
 
       - id: set-release-name
         run: echo "RELEASE_NAME=$(git describe --tags)" >> $GITHUB_ENV
@@ -31,6 +31,9 @@ jobs:
           echo "$message" >> $GITHUB_ENV
           echo 'GIT' >> $GITHUB_ENV
 
+      - id: set-previous-release-name
+        run: echo "PREVIOUS_RELEASE_NAME=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))" >> $GITHUB_ENV
+
       - name: Create Draft Release
         id: create-draft-release
         uses: actions/create-release@v1
@@ -41,7 +44,8 @@ jobs:
           release_name: ${{ github.ref }}
           body: |
             ${{ env.RELEASE_MESSAGE }}
-
+            
+            **Full Changelog**: https://github.com/jdenoc/laravel-make-trait/compare/${{ env.PREVIOUS_RELEASE_NAME }}...${{ env.RELEASE_NAME }}
           draft: true
           prerelease: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/composer-cache
-          key: cache-composer-${{ hashFiles('composer.lock') }}-${{ matrix.php-version }}
+          key: cache-composer-${{ hashFiles('composer.json') }}-${{ matrix.php-version }}
 
-      - uses: php-actions/composer@v5
+      - uses: php-actions/composer@v6
         with:
           php_version: ${{ matrix.php-version }}
           version: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ '7.2', '7.3', '7.4' ]
+        php-version: [ '7.2', '7.3', '7.4', '8.0' ]
     name: PHP ${{ matrix.php-version }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ '7.2', '7.3', '7.4', '8.0' ]
+        php-version: [ '7.2', '7.3', '7.4' ]
     name: PHP ${{ matrix.php-version }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-# .github/workflows/main.yml
+# .github/workflows/tests.yml
 name: Laravel artisan make:trait
 
 # Controls when the action will run.

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 vendor
 composer.lock
+.phpunit.result.cache
+.idea
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ vendor/bin/phpunit --stop-on-failure
 - 7.2
 - 7.3
 - 7.4
+- 8.0
+
+### Laravel Version Support
+- Laravel 7.0
+- Laravel 6.0
+  - Use version [1.0.1](https://github.com/jdenoc/laravel-make-trait/tree/1.0.1)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ vendor/bin/phpunit --stop-on-failure
 - 7.2
 - 7.3
 - 7.4
-- 8.0
 
 ### Laravel Version Support
 - Laravel 7.0

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/support": "^6.0"
+        "illuminate/support": "^7.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0",
+        "orchestra/testbench": "^5.0",
         "phpunit/phpunit": "^8.0"
     },
     "autoload": {


### PR DESCRIPTION
- Added a changelog link to the draft-release GitHub Actions Workflow.
- Adding support for PHP 8.0.
- Bumped the Github Actions php-action/composer version used.
- Within the Github Actions workflow main, caching composer dependencies now based on composer.json instead of composer.lock.
- Bumping dependencies to work with Laravel 7.x.
- Ignoring some extra files.
- Renamed the GitHub Actions workflow `main` to `tests`.